### PR TITLE
remove version and link in docker-compose

### DIFF
--- a/run/docker-compose.yaml
+++ b/run/docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   db:
     image: postgres:14.1-alpine
@@ -30,8 +29,6 @@ services:
       - WEB_PORT=${WEB_PORT}
     volumes:
       - ../golang_server:/opt/app/api
-    links:
-      - db
 volumes:
   db:
     driver: local


### PR DESCRIPTION
These options are not available in later versions of docker-compose